### PR TITLE
Fix targeting docs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ OpenFeature.set_global_context(%{region: "us-east-1"})
 client = OpenFeature.get_client() |> OpenFeature.Client.set_context(%{region: "us-east-1"})
 
 # set a value to the invocation context
-flag_value = OpenFeature.Client.get_boolean_value(client, "some-flag", flag, %{region: "us-east-1"})
+flag_value = OpenFeature.Client.get_boolean_value(client, "some-flag", flag, context: %{region: "us-east-1"})
 ```
 
 ### Hooks


### PR DESCRIPTION
## This PR

Updates the README to correct a non-working example.


### Notes

The context for targeting needs to be passed in as a keyword list instead of directly as the 4th argument

