### PR TITLE
fix: incorrect event handler type in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ Please refer to the documentation of the provider you're using to see what event
 
 ```elixir
 # add an event handler to a client
-OpenFeature.Client.add_event_handler(client, :provider_configuration_changed, fn event_details ->
+OpenFeature.Client.add_event_handler(client, :configuration_changed, fn event_details ->
   # do something when the provider's flag settings change
 end)
 ```


### PR DESCRIPTION
## This PR

Update the README to fix the incorrect atom used in the event handler example. This should match the atom defined in `lib/open_feature/types.ex`.