### PR TITLE
fix: unused provider shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## v0.1.2 (2025-06-23)
+
+- fix: unused provider shutdown
+
+## v0.1.1 (2024-08-02)
+
+- chore: use readme template
+
 ## v0.1.0 (2024-07-29)
 
 - Initial release

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@
   </a>
   <!-- x-release-please-start-version -->
 
-  <a href="https://github.com/open-feature/elixir-sdk/releases/tag/v0.1.1">
-    <img alt="Release" src="https://img.shields.io/static/v1?label=release&message=v0.1.1&color=blue&style=for-the-badge" />
+  <a href="https://github.com/open-feature/elixir-sdk/releases/tag/v0.1.2">
+    <img alt="Release" src="https://img.shields.io/static/v1?label=release&message=v0.1.2&color=blue&style=for-the-badge" />
   </a>
 
   <!-- x-release-please-end -->
@@ -86,7 +86,7 @@ For details, including API documentation, see the respective [Hex docs](https://
 
 | Status | Features                                                            | Description                                                                                                                                                  |
 | ------ | --------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| ⚠️      | [Providers](#providers)                                             | Integrate with a commercial, open source, or in-house feature management tool.                                                                               |
+| ✅      | [Providers](#providers)                                             | Integrate with a commercial, open source, or in-house feature management tool.                                                                               |
 | ✅      | [Targeting](#targeting)                                             | Contextually-aware flag evaluation using [evaluation context](https://openfeature.dev/docs/reference/concepts/evaluation-context).                           |
 | ✅      | [Hooks](#hooks)                                                     | Add functionality to various stages of the flag evaluation life-cycle.                                                                                       |
 | ✅      | [Logging](#logging)                                                 | Integrate with popular logging packages.                                                                                                                     |

--- a/lib/open_feature/provider.ex
+++ b/lib/open_feature/provider.ex
@@ -125,6 +125,7 @@ defmodule OpenFeature.Provider do
   Checks if two providers are equal based on their name, domain, and state.
   """
   @doc since: "0.1.0"
+  @doc deprecated: "This function will be removed in the next major version."
   @spec equal?(t, t) :: boolean
   def equal?(%module1{} = provider1, %module2{} = provider2) do
     module1 == module2 &&

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule OpenFeature.MixProject do
   def project do
     [
       app: :open_feature,
-      version: "0.1.1",
+      version: "0.1.2",
       elixir: "~> 1.14",
       start_permanent: Mix.env() == :prod,
       test_paths: ["test/unit", "test/integration"],

--- a/test/unit/open_feature_test.exs
+++ b/test/unit/open_feature_test.exs
@@ -14,8 +14,8 @@ defmodule OpenFeatureTest do
 
       Provider
       |> expect(:validate_provider, fn ^provider -> {:ok, provider} end)
-      |> expect(:equal?, fn nil, ^provider -> false end)
       |> expect(:initialize, fn ^domain, ^provider, ^context -> {:ok, provider} end)
+      |> expect(:shutdown, fn _old_provider -> :ok end)
 
       Store
       |> expect(:set_provider, fn ^domain, ^provider -> :ok end)
@@ -30,9 +30,7 @@ defmodule OpenFeatureTest do
       provider = %NoOp{}
       domain = "default"
 
-      Provider
-      |> expect(:validate_provider, fn ^provider -> {:ok, provider} end)
-      |> expect(:equal?, fn ^provider, ^provider -> true end)
+      expect(Provider, :validate_provider, fn ^provider -> {:ok, provider} end)
 
       expect(Store, :get_provider, fn ^domain -> provider end)
 


### PR DESCRIPTION
## This PR

When a new provider was being set, the old provider was not being properly shutdown.
It should now be properly shutdown if not set for any other domain.
