### PR TITLE
fix: do not perform flag resolution if not ready

### DIFF
--- a/lib/open_feature/types.ex
+++ b/lib/open_feature/types.ex
@@ -19,7 +19,7 @@ defmodule OpenFeature.Types do
           | :general
   @type reason :: :static | :default | :targeting_match | :split | :cached | :disabled | :unknown | :stale | :error
   @type flag_metadata :: %{binary => boolean | binary | number}
-  @type provider_status :: :not_ready | :ready | :stale
+  @type provider_status :: :not_ready | :ready | :error | :stale | :fatal
   @type event_type :: :ready | :error | :configuration_changed | :stale
   @type event_details :: %{:provider => binary, optional(:domain) => binary, optional(binary | atom) => any}
   @type event_handler :: (event_details -> any())

--- a/test/integration/value_resolution_test.exs
+++ b/test/integration/value_resolution_test.exs
@@ -58,7 +58,7 @@ defmodule Integration.ValueResolutionTest do
                variant: nil,
                reason: :error,
                error_code: :general,
-               error_message: "variant not found"
+               error_message: "variant not found, variant: \"variant2\""
              } =
                Client.get_string_details(client, "target_key", "default", context: %{variant: "variant2"})
     end


### PR DESCRIPTION
## This PR

The flag resolution was being performed regardless of the state of the client provider.
Now, if the provider state is `:not_ready` or `:fatal`, it will not attempt to resolve the flag value.
