### PR TITLE
fix: providers are equal

### DIFF
--- a/lib/open_feature/provider.ex
+++ b/lib/open_feature/provider.ex
@@ -122,16 +122,12 @@ defmodule OpenFeature.Provider do
   end
 
   @doc """
-  Checks if two providers are equal based on their name, domain, and state.
+  Checks if two providers are equal based on their module and name.
   """
   @doc since: "0.1.0"
-  @doc deprecated: "This function will be removed in the next major version."
   @spec equal?(t, t) :: boolean
   def equal?(%module1{} = provider1, %module2{} = provider2) do
-    module1 == module2 &&
-      provider1.name == provider2.name &&
-      provider1.domain == provider2.domain &&
-      provider1.state == provider2.state
+    module1 == module2 && provider1.name == provider2.name
   end
 
   def equal?(_, _), do: false

--- a/test/unit/open_feature/provider_test.exs
+++ b/test/unit/open_feature/provider_test.exs
@@ -100,7 +100,7 @@ defmodule OpenFeature.ProviderTest do
     test "should return false if the provided providers are not equal" do
       refute Provider.equal?(@no_op_provider, @in_memory_provider)
 
-      different_no_op = Map.put(@no_op_provider, :domain, "some_domain")
+      different_no_op = Map.put(@no_op_provider, :name, "some_name")
       refute Provider.equal?(@no_op_provider, different_no_op)
     end
   end


### PR DESCRIPTION
## This PR

Reverted the change to make the function Provider.equal?/2 deprecated and changed it to check if two providers are equal if they have the same module and name.
